### PR TITLE
feat: expand combat upgrades and floor feedback

### DIFF
--- a/game/src/game/scenes/Boot.ts
+++ b/game/src/game/scenes/Boot.ts
@@ -223,6 +223,14 @@ export class Boot extends Phaser.Scene {
       g.clear()
     })
 
+    ensure('drone', g => {
+      g.lineStyle(2, 0x000000, 1).strokeCircle(6, 6, 5)
+      g.fillStyle(0x9cfba5).fillCircle(6, 6, 4)
+      g.fillStyle(0xffffff, 0.8).fillCircle(8, 4, 1.5)
+      g.generateTexture('drone', 12, 12)
+      g.clear()
+    })
+
     // Pixel-perfect camera rounding across scenes
     this.cameras.main.setRoundPixels(true)
 

--- a/game/src/game/scenes/GameSceneRefactored.ts
+++ b/game/src/game/scenes/GameSceneRefactored.ts
@@ -685,6 +685,8 @@ export class GameScene extends Phaser.Scene {
       attackCooldown: rs.attackCooldown,
       projSpeed: rs.projSpeed,
       projCount: rs.projCount,
+      projectileDamage: rs.projectileDamage,
+      pierceTargets: rs.pierceTargets,
       hasMagnet: rs.hasMagnet,
       magnetRadius: rs.magnetRadius,
       hasBlast: rs.hasBlast,
@@ -693,10 +695,19 @@ export class GameScene extends Phaser.Scene {
       maxHp: rs.maxHp,
       fireRateLv: rs.fireRateLv,
       projLv: rs.projLv,
+      projSpeedLv: rs.projSpeedLv,
+      damageLv: rs.damageLv,
+      pierceLv: rs.pierceLv,
       speedLv: rs.speedLv,
       magnetLv: rs.magnetLv,
       blastLv: rs.blastLv,
-    });
+      staticFieldLv: rs.staticFieldLv,
+      staticFieldCooldown: rs.staticFieldCooldown,
+      staticFieldRadius: rs.staticFieldRadius,
+      staticFieldDamage: rs.staticFieldDamage,
+      droneLevel: rs.droneLevel,
+      droneDamage: rs.droneDamage,
+    } as any);
     this.lastDamageAt = this.time.now;
     this.regenAccumulator = 0;
     this.scheduleAttack();
@@ -713,6 +724,8 @@ export class GameScene extends Phaser.Scene {
       attackCooldown: stats.attackCooldown,
       projSpeed: stats.projSpeed,
       projCount: stats.projCount,
+      projectileDamage: (stats as any).projectileDamage ?? 1,
+      pierceTargets: (stats as any).pierceTargets ?? 0,
       hasMagnet: stats.hasMagnet,
       magnetRadius: stats.magnetRadius,
       hasBlast: stats.hasBlast,
@@ -721,9 +734,18 @@ export class GameScene extends Phaser.Scene {
       maxHp: stats.maxHp,
       fireRateLv: stats.fireRateLv,
       projLv: stats.projLv,
+      projSpeedLv: (stats as any).projSpeedLv ?? 0,
+      damageLv: (stats as any).damageLv ?? 0,
+      pierceLv: (stats as any).pierceLv ?? ((stats as any).pierceTargets ?? 0),
       speedLv: stats.speedLv,
       magnetLv: stats.magnetLv,
       blastLv: stats.blastLv,
+      staticFieldLv: (stats as any).staticFieldLv ?? 0,
+      staticFieldCooldown: (stats as any).staticFieldCooldown ?? 4500,
+      staticFieldRadius: (stats as any).staticFieldRadius ?? 120,
+      staticFieldDamage: (stats as any).staticFieldDamage ?? 1,
+      droneLevel: (stats as any).droneLevel ?? 0,
+      droneDamage: (stats as any).droneDamage ?? 1,
     };
     saveRunState(rs);
   }

--- a/game/src/state/run.ts
+++ b/game/src/state/run.ts
@@ -8,6 +8,8 @@ export interface RunBuild {
   attackCooldown: number
   projSpeed: number
   projCount: number
+  projectileDamage: number
+  pierceTargets: number
   hasMagnet: boolean
   magnetRadius: number
   hasBlast: boolean
@@ -17,9 +19,18 @@ export interface RunBuild {
   // Upgrade counters for UI
   fireRateLv: number
   projLv: number
+  projSpeedLv: number
+  damageLv: number
+  pierceLv: number
   speedLv: number
   magnetLv: number
   blastLv: number
+  staticFieldLv: number
+  staticFieldCooldown: number
+  staticFieldRadius: number
+  staticFieldDamage: number
+  droneLevel: number
+  droneDamage: number
 }
 
 const KEY = 'limitless:runstate:v1'
@@ -35,7 +46,64 @@ export function loadRunState(): RunBuild | null {
     const parsed = JSON.parse(raw) as Partial<RunBuild>
     const maxHp = typeof parsed.maxHp === 'number' ? parsed.maxHp : DEFAULT_MAX_HP
     const hp = typeof parsed.hp === 'number' ? parsed.hp : maxHp
-    return { ...parsed, maxHp, hp } as RunBuild
+    const level = typeof parsed.level === 'number' ? parsed.level : 1
+    const xp = typeof parsed.xp === 'number' ? parsed.xp : 0
+    const xpToNext = typeof parsed.xpToNext === 'number' ? parsed.xpToNext : 5
+    const speed = typeof parsed.speed === 'number' ? parsed.speed : 160
+    const attackCooldown = typeof parsed.attackCooldown === 'number' ? parsed.attackCooldown : 800
+    const projSpeed = typeof parsed.projSpeed === 'number' ? parsed.projSpeed : 300
+    const projCount = typeof parsed.projCount === 'number' ? parsed.projCount : 1
+    const projectileDamage = typeof parsed.projectileDamage === 'number' ? parsed.projectileDamage : 1
+    const pierceTargets = typeof parsed.pierceTargets === 'number' ? parsed.pierceTargets : 0
+    const hasMagnet = !!parsed.hasMagnet
+    const magnetRadius = typeof parsed.magnetRadius === 'number' ? parsed.magnetRadius : (hasMagnet ? 120 : 0)
+    const hasBlast = !!parsed.hasBlast
+    const attackRadius = typeof parsed.attackRadius === 'number' ? parsed.attackRadius : 100
+    const fireRateLv = typeof parsed.fireRateLv === 'number' ? parsed.fireRateLv : 0
+    const projLv = typeof parsed.projLv === 'number' ? parsed.projLv : 0
+    const projSpeedLv = typeof parsed.projSpeedLv === 'number' ? parsed.projSpeedLv : 0
+    const damageLv = typeof parsed.damageLv === 'number' ? parsed.damageLv : Math.max(0, projectileDamage - 1)
+    const pierceLv = typeof parsed.pierceLv === 'number' ? parsed.pierceLv : pierceTargets
+    const speedLv = typeof parsed.speedLv === 'number' ? parsed.speedLv : 0
+    const magnetLv = typeof parsed.magnetLv === 'number' ? parsed.magnetLv : (hasMagnet ? 1 : 0)
+    const blastLv = typeof parsed.blastLv === 'number' ? parsed.blastLv : (hasBlast ? 1 : 0)
+    const staticFieldLv = typeof parsed.staticFieldLv === 'number' ? parsed.staticFieldLv : 0
+    const staticFieldCooldown = typeof parsed.staticFieldCooldown === 'number' ? parsed.staticFieldCooldown : 4500
+    const staticFieldRadius = typeof parsed.staticFieldRadius === 'number' ? parsed.staticFieldRadius : 120
+    const staticFieldDamage = typeof parsed.staticFieldDamage === 'number' ? parsed.staticFieldDamage : 1
+    const droneLevel = typeof parsed.droneLevel === 'number' ? parsed.droneLevel : 0
+    const droneDamage = typeof parsed.droneDamage === 'number' ? parsed.droneDamage : Math.min(5, 1 + Math.max(0, droneLevel - 3))
+    return {
+      level,
+      xp,
+      xpToNext,
+      speed,
+      attackCooldown,
+      projSpeed,
+      projCount,
+      projectileDamage,
+      pierceTargets,
+      hasMagnet,
+      magnetRadius,
+      hasBlast,
+      attackRadius,
+      hp,
+      maxHp,
+      fireRateLv,
+      projLv,
+      projSpeedLv,
+      damageLv,
+      pierceLv,
+      speedLv,
+      magnetLv,
+      blastLv,
+      staticFieldLv,
+      staticFieldCooldown,
+      staticFieldRadius,
+      staticFieldDamage,
+      droneLevel,
+      droneDamage,
+    }
   } catch { return null }
 }
 


### PR DESCRIPTION
## Summary
- add a render-textured floor grid with palette-aware tinting so movement reads better
- overhaul level-up choices with projectile damage, piercing, guardian drones, and static field upgrades
- surface new build stats in the HUD and persist them in the run-state schema

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2429d39c832394aab99ac4514fcc